### PR TITLE
Update library.properties version to match latest release

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RFExplorer 3GP IoT
-version=1.0.1804
+version=1.0.1806
 author=RFExplorer Team
 maintainer=RF Explorer Team <contact@rf-explorer.com>
 sentence=Library reference for RFExplorer 3GP IoT


### PR DESCRIPTION
Ideally the version value in library.properties would be updated before the release/tag is created. 

For libraries in the [Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ), if a previous tag with the same library.properties version value was already added to the Library Manager index then the new tag will not be added.

Reference:
https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ#how-can-i-publish-a-new-release-once-my-library-is-in-the-list